### PR TITLE
test: testes criam e checam pelos arquivos em caminho não hard coded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ng-material-theme",
+  "name": "@wizsolucoes/ng-material-theme",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -27,13 +27,133 @@
       }
     },
     "@schematics/angular": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-10.2.0.tgz",
-      "integrity": "sha512-rJRTTTL8CMMFb3ebCvAVHKHxuNzRqy/HtbXhJ82l5Xo/jXcm74eV2Q0RBUrNo1yBKWFIR+FIwiXLJaGcC/R9Pw==",
+      "version": "9.1.12",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-9.1.12.tgz",
+      "integrity": "sha512-r4+aPAGhstsKFMwW/kOen1ACnzuLpz+vMxEpndXOqqVXLkAMsuAbQUFYjIlMy6fH4zdhpI90EJZ1PbOrAXvKxA==",
       "requires": {
-        "@angular-devkit/core": "10.2.0",
-        "@angular-devkit/schematics": "10.2.0",
-        "jsonc-parser": "2.3.0"
+        "@angular-devkit/core": "9.1.12",
+        "@angular-devkit/schematics": "9.1.12"
+      },
+      "dependencies": {
+        "@angular-devkit/core": {
+          "version": "9.1.12",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-9.1.12.tgz",
+          "integrity": "sha512-D/GnBeSlmdgGn7EhuE32HuPuRAjvUuxi7Q6WywBI8PSsXKAGnrypghBwMATNnOA24//CgbW2533Y9VWHaeXdeA==",
+          "requires": {
+            "ajv": "6.12.3",
+            "fast-json-stable-stringify": "2.1.0",
+            "magic-string": "0.25.7",
+            "rxjs": "6.5.4",
+            "source-map": "0.7.3"
+          }
+        },
+        "@angular-devkit/schematics": {
+          "version": "9.1.12",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-9.1.12.tgz",
+          "integrity": "sha512-+GYnUzmIy1/QpYitCC8mI7jcrViGHTtOKvvDPEFjU2nggjNEQaMmsHcdIsjrqggEc23ZZyebNAIewT8CMkJyrQ==",
+          "requires": {
+            "@angular-devkit/core": "9.1.12",
+            "ora": "4.0.3",
+            "rxjs": "6.5.4"
+          }
+        },
+        "ajv": {
+          "version": "6.12.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "log-symbols": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+          "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+          "requires": {
+            "chalk": "^2.4.2"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "ora": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-4.0.3.tgz",
+          "integrity": "sha512-fnDebVFyz309A73cqCipVL1fBZewq4vwgSHfxh43vVy31mbyoQ8sCH3Oeaog/owYOs/lLlGVPCISQonTneg6Pg==",
+          "requires": {
+            "chalk": "^3.0.0",
+            "cli-cursor": "^3.1.0",
+            "cli-spinners": "^2.2.0",
+            "is-interactive": "^1.0.0",
+            "log-symbols": "^3.0.0",
+            "mute-stream": "0.0.8",
+            "strip-ansi": "^6.0.0",
+            "wcwidth": "^1.0.1"
+          }
+        },
+        "rxjs": {
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
+          "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        }
       }
     },
     "@types/jasmine": {
@@ -142,6 +262,11 @@
         "clone": "^1.0.2"
       }
     },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -218,11 +343,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    },
-    "jsonc-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.0.tgz",
-      "integrity": "sha512-b0EBt8SWFNnixVdvoR2ZtEGa9ZqLhbJnOjezn+WP+8kspFm+PFYDN8Z4Bc7pRlDjvuVcADSUkroIuTWWn/YiIA=="
     },
     "log-symbols": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wizsolucoes/ng-material-theme",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wizsolucoes/ng-material-theme",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Schematics para instalação do Angular Material com tema Wiz",
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@angular-devkit/core": "^10.2.0",
     "@angular-devkit/schematics": "^10.2.0",
-    "@schematics/angular": "^10.2.0",
+    "@schematics/angular": "^9.1.12",
     "typescript": "~4.0.2"
   },
   "devDependencies": {

--- a/src/ng-material-theme/index_spec.ts
+++ b/src/ng-material-theme/index_spec.ts
@@ -23,7 +23,7 @@ describe("ng-material-theme", () => {
       .runExternalSchematicAsync(
         "@schematics/angular",
         "application",
-        { name: "my-app", style: 'scss', projectRoot: './' },
+        { name: "my-app", style: 'scss' },
         appTree
       )
       .toPromise();
@@ -49,8 +49,8 @@ describe("ng-material-theme", () => {
       appTree
     ).toPromise();
 
-    expect(tree.files).toContain('/src/theme.scss');
-    expect(tree.files).toContain('/src/custom-component-themes.scss');
+    expect(tree.files).toContain('/my-app/src/theme.scss');
+    expect(tree.files).toContain('/my-app/src/custom-component-themes.scss');
   });
 
   it("should update the \'styles.scss\' file on \'src\' folder", async () => {
@@ -60,7 +60,7 @@ describe("ng-material-theme", () => {
       appTree
     ).toPromise();
 
-    const styles = tree.read('/src/styles.scss')!.toString('utf-8');
+    const styles = tree.read('/my-app/src/styles.scss')!.toString('utf-8');
     
     expect(styles).toContain("@import '~@angular/material/theming';");
     expect(styles).toContain("@import './custom-component-themes.scss';");


### PR DESCRIPTION
Correção na forma como os testes criam e checam os arquivos do schematics. A forma anterior - hard coded - gerava problema ao realizar o teste em conjunto com outros Schematics como, por exemplo, o @wizsolucoes/angular-starter.

Versão alterada de 1.0.0 para 1.0.1