### PR TITLE
Fix/styles file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wizsolucoes/ng-material-theme",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Schematics para instalação do Angular Material com tema Wiz",
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/src/ng-material-theme/index.ts
+++ b/src/ng-material-theme/index.ts
@@ -91,41 +91,14 @@ function updateStylesFile(_options: Schema) {
     const filePath = defaultProjectPath.replace('/app', '/styles.scss');
     const styles = tree.read(filePath)!.toString();
 
-    const updatedStyles = _options['white-label'] ? styles.concat(
-      `:root {
-  --primary-color: #FF9100;
-  --accent-color: #006eb4;
-  --syz-primary-color: var(--primary-color);
-  --syz-accent-color: var(--accent-color);
-}
-
-* {
-  margin: 0;
-  padding: 0;
-  outline: 0;
-  box-sizing: border-box;
-}
-
-body {
-  font-family: 'Roboto', 'Heebo', sans-serif;
-}
-
+    const updatedStyles = styles.concat(`
 // Custom Theming for Angular Material
 // For more information: https://material.angular.io/guide/theming
 @import '~@angular/material/theming';
 
 // Plus imports for other components in your app.
 @import './custom-component-themes.scss';
-@import './theme.scss';`
-    ) : styles.concat(`
-// Custom Theming for Angular Material
-// For more information: https://material.angular.io/guide/theming
-@import '~@angular/material/theming';
-
-// Plus imports for other components in your app.
-@import './custom-component-themes.scss';
-@import './theme.scss';\n`
-    );
+@import './theme.scss';\n`);
 
     tree.overwrite(filePath, updatedStyles);
 

--- a/src/ng-material-theme/index_spec.ts
+++ b/src/ng-material-theme/index_spec.ts
@@ -44,6 +44,20 @@ describe("ng-material-theme", () => {
     expect(packageFile.dependencies['@angular/cdk']).toBeTruthy();
   });
 
+  it("should update the \'styles.scss\' file on \'src\' folder", async () => {
+    const tree = await runner.runSchematicAsync(
+      'ng-material-theme',
+      { 'white-label': false },
+      appTree
+    ).toPromise();
+
+    const styles = tree.read('/my-app/src/styles.scss')!.toString('utf-8');
+    
+    expect(styles).toContain("@import '~@angular/material/theming';");
+    expect(styles).toContain("@import './custom-component-themes.scss';");
+    expect(styles).toContain("@import './theme.scss';");
+  });
+
   it('should fail if missing tree', async () => {
     await expectAsync(
       runner.runSchematicAsync(
@@ -72,20 +86,6 @@ describe("ng-material-theme", () => {
       expect(createdThemeFile).toEqual(baseThemeFile);
       expect(tree.files).toContain('/my-app/src/custom-component-themes.scss');
     });
-
-    it("should update the \'styles.scss\' file on \'src\' folder", async () => {
-      const tree = await runner.runSchematicAsync(
-        'ng-material-theme',
-        { 'white-label': false },
-        appTree
-      ).toPromise();
-  
-      const styles = tree.read('/my-app/src/styles.scss')!.toString('utf-8');
-      
-      expect(styles).toContain("@import '~@angular/material/theming';");
-      expect(styles).toContain("@import './custom-component-themes.scss';");
-      expect(styles).toContain("@import './theme.scss';");
-    });
   });
 
   describe('White Label application', () => {
@@ -105,26 +105,6 @@ describe("ng-material-theme", () => {
       expect(tree.files).toContain('/my-app/src/theme.scss');
       expect(createdThemeFile).toEqual(baseThemeFile);
       expect(tree.files).toContain('/my-app/src/custom-component-themes.scss');
-    });
-
-    it("should update the \'styles.scss\' file on \'src\' folder", async () => {
-      const tree = await runner.runSchematicAsync(
-        'ng-material-theme',
-        { 'white-label': true },
-        appTree
-      ).toPromise();
-  
-      const styles = tree.read('/my-app/src/styles.scss')!.toString('utf-8');
-      
-      expect(styles).toContain("@import '~@angular/material/theming';");
-      expect(styles).toContain("@import './custom-component-themes.scss';");
-      expect(styles).toContain("@import './theme.scss';");
-      expect(styles).toContain(`:root {
-  --primary-color: #FF9100;
-  --accent-color: #006eb4;
-  --syz-primary-color: var(--primary-color);
-  --syz-accent-color: var(--accent-color);
-}`);
     });
   });
 });


### PR DESCRIPTION
Correção na concatenação da folha de estilos. A versão anterior, após execução do schematic no @wizsolucoes/angular-white-label, gerava regras duplicadas no arquivo 'styles.scss'. Problema corrigido. Versão alterada de 1.1.0 para 1.1.1.